### PR TITLE
Relax kaminari-core dep version constraint

### DIFF
--- a/kaminari-mongoid.gemspec
+++ b/kaminari-mongoid.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'kaminari-core', Kaminari::Mongoid::VERSION
+  spec.add_dependency 'kaminari-core', "~> #{Kaminari::Mongoid::VERSION}"
   spec.add_dependency 'mongoid'
 
   spec.add_development_dependency "bundler", "~> 1.9"


### PR DESCRIPTION
I can't use version 1.0.0 of this gem in conjunction with kaminari 1.0.1
because version constraint requires a kaminari-core version that is equal
to this gem version, that is = 1.0.0 in this case.

Example error:

```
Resolving dependencies...
Bundler could not find compatible versions for gem "kaminari-core":
  In snapshot (Gemfile.lock):
    kaminari-core (= 1.0.1)

  In Gemfile:
    kaminari (~> 1.0) was resolved to 1.0.1, which depends on
      kaminari-core (= 1.0.1)

    kaminari (~> 1.0) was resolved to 1.0.1, which depends on
      kaminari-core (= 1.0.1)

    kaminari (~> 1.0) was resolved to 1.0.1, which depends on
      kaminari-core (= 1.0.1)

    kaminari-mongoid (~> 1.0) was resolved to 1.0.0, which depends on
      kaminari-core (= 1.0.0)
```

See also https://github.com/tomatoes-app/tomatoes/pull/233.