### PR TITLE
Pagination without finding total count

### DIFF
--- a/lib/kaminari/mongoid/mongoid_criteria_methods.rb
+++ b/lib/kaminari/mongoid/mongoid_criteria_methods.rb
@@ -31,13 +31,40 @@ module Kaminari
         end
       end
 
+      def without_count
+        extend ::Kaminari::PaginatableWithoutCount
+      end
+
       private
+
       def unpage
         clone.tap do |crit|
           crit.options.delete :limit
           crit.options.delete :skip
         end
       end
+    end
+  end
+end
+
+module Kaminari
+  module PaginatableWithoutCount
+    # Method used to find last page, force setting to false and then use @records.present?
+    # in views to determine if link_to_next_page needs to be displayed.
+    def last_page?
+      false
+    end
+
+    # Method used to check if current page greater than total pages, force setting to false and then use @records.present?
+    # in views to determine if link_to_next_page needs to be displayed.
+    def out_of_range?
+      false
+    end
+
+    # Force to raise an exception if #total_count is called explicitly.
+    def total_count
+      raise "This scope is marked as a non-count paginable scope and can't be used in combination " \
+            "with `#paginate' or `#page_entries_info'. Use #link_to_next_page or #link_to_previous_page instead."
     end
   end
 end

--- a/test/models/mongoid/mongoid_test.rb
+++ b/test/models/mongoid/mongoid_test.rb
@@ -11,6 +11,20 @@ class MongoidCriteriaMethodsTest < ActiveSupport::TestCase
       assert_equal 1, User.page.tap(&:total_count).where(salary: 1).total_count
     end
   end
+
+  sub_test_case '#without_count' do
+    setup do
+      5.times { User.with(database: 'without_count_db') { |u| u.create!(salary: 1) } }
+    end
+
+    test 'it should use default settings for last_page and out_of_range' do
+      users = User.max_scan(20).page(1).without_count
+
+      assert_instance_of Mongoid::Criteria, users
+      assert_equal false, users.last_page?
+      assert_equal false, users.out_of_range?
+    end
+  end
 end
 
 class MongoidExtensionTest < ActiveSupport::TestCase


### PR DESCRIPTION
Simple without count mode 
As mongoid doesn't preload records, force setting last_page?, out_of_range? methods. 
One flaw this way approach is it shows one blank page before it disables next button.

Usage
<% link_to_previous_page @users, 'Previous' %>
<% link_to_next_page @users, 'Next'  unless @users.empty? %>