### PR TITLE
Use estimated_count instead of size on unfiltered criterias with Mongoid >= 7.2.0

### DIFF
--- a/lib/kaminari/mongoid/mongoid_criteria_methods.rb
+++ b/lib/kaminari/mongoid/mongoid_criteria_methods.rb
@@ -38,6 +38,14 @@ module Kaminari
           crit.options.delete :skip
         end
       end
+
+      def size
+        if Gem::Version.new(::Mongoid::VERSION) >= Gem::Version.new('7.2.0') && criteria.selector.empty?
+          unpage.estimated_count
+        else
+          super
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
With mongoid `7.2.0` comes a change that may bring performances issue to kaminari

The `.count` method will really count documents when used without filters, instead of using the estimate count stored in the collection https://github.com/mongodb/mongoid/pull/4808/files

kaminari-mongoid uses `size` which is an alias for `count`, my approach is to override it to use `estimate_count` when we can 

I didn't add any spec since it's not changing any expected result nor fixing anything